### PR TITLE
Fix naming of ROOTFSPART_SIZE

### DIFF
--- a/conf/machine/orin-nx-8g.conf
+++ b/conf/machine/orin-nx-8g.conf
@@ -38,7 +38,7 @@ EMMC_SIZE ?= ""
 BOOTPART_SIZE ?= "8388608"
 # 55GiB default rootfs size
 #ROOTFSPART_SIZE ?= "59055800320"
-ROOTFSPART_SIZE ?= "8589934592"
+ROOTFSPART_SIZE_DEFAULT ?= "8589934592"
 ODMDATA ?= "gbe-uphy-config-8,hsstp-lane-map-3,hsio-uphy-config-0"
 EMMC_BCT ?= "tegra234-p3767-0001-sdram-l4t.dts"
 NVIDIA_BOARD ?= "t186ref"


### PR DESCRIPTION
Fixes an issue which caused the image not to build because it wanted ROOTFSPART_SIZE_DEFAULT and not ROOTFSPART_SIZE