### PR TITLE
Add package for nvbootctrl

### DIFF
--- a/recipes-bsp/images/frc971-image.bb
+++ b/recipes-bsp/images/frc971-image.bb
@@ -50,6 +50,7 @@ IMAGE_INSTALL:append = "\
     cuda-cudart-11-8-dev \
     cuda-target-environment \
     tegra-tools-jetson-clocks \
+    tegra-redundant-boot-base \
     nsight-systems-cli \
     nsight-systems-cli-qdstrmimporter \
 "


### PR DESCRIPTION
This package gives us the binary needed to be able to control boot slots. Separately, we'll also probably need to add `CONFIG_EFI_RUNTIME_MAP` to the kernel config but let's do that after verifying it actually fixes the problem.