### PR TITLE
Add the canivore-usb kernel module

### DIFF
--- a/conf/machine/orin-nx-8g.conf
+++ b/conf/machine/orin-nx-8g.conf
@@ -17,6 +17,8 @@ TEGRAFLASH_NO_INTERNAL_STORAGE = "1"
 require conf/machine/include/tegra234.inc
 require conf/machine/include/devkit-wifi.inc
 
+KERNEL_VERSION_SANITY_SKIP="1"
+
 TEGRA_BUPGEN_SPECS ?= "fab=000;boardsku=0000;boardrev=;bup_type=bl \
                        fab=000;boardsku=0000;boardrev=;bup_type=kernel \
                        fab=000;boardsku=0001;boardrev=;bup_type=bl \

--- a/recipes-bsp/images/frc971-image.bb
+++ b/recipes-bsp/images/frc971-image.bb
@@ -42,6 +42,7 @@ IMAGE_INSTALL:append = "\
     e2fsprogs-resize2fs \
     v4l-utils \
     nv-imx296-mod \
+    canivore-usb-mod \
     trace-cmd \
     sysstat \
     gdb \

--- a/recipes-kernel/canivore-usb-mod/canivore-usb-mod_24.2.0.bb
+++ b/recipes-kernel/canivore-usb-mod/canivore-usb-mod_24.2.0.bb
@@ -1,0 +1,30 @@
+SUMMARY = "Example of how to build an external Linux kernel module"
+DESCRIPTION = "${SUMMARY}"
+LICENSE = "GPL-2.0-only"
+LIC_FILES_CHKSUM = "file://${WORKDIR}/usr/src/canivore-usb-1.12/canivore-usb-drv.c;begineline=6;endline=14;md5=7ea7c5833705625b82e746f2748a3ef2"
+
+inherit module
+
+SRC_URI = "https://deb.ctr-electronics.com/tools/packages/canivore-usb_1.12_arm64.deb"
+SRC_URI += "file://Makefile"
+SRC_URI[sha256sum] = "e3f63b95f39fd78e9e840d4bf599ae504e219f2c3d364bce9ea76a85bb1d2fe7"
+
+S = "${WORKDIR}/usr/src/canivore-usb-1.12"
+
+do_setup() {
+    cp "${WORKDIR}/Makefile" "${WORKDIR}/usr/src/canivore-usb-1.12"
+    mv "${WORKDIR}/usr/src/canivore-usb-1.12/canivore-usb-util.10.o_shipped" \
+        "${WORKDIR}/usr/src/canivore-usb-1.12/canivore-usb-util.o_shipped"
+
+    rm "${WORKDIR}/usr/src/canivore-usb-1.12/caniv"
+    rm "${WORKDIR}/usr/src/canivore-usb-1.12/canivore_setup"
+    rm "${WORKDIR}/usr/src/canivore-usb-1.12/canivore_shutdown"
+    rm "${WORKDIR}/usr/src/canivore-usb-1.12/dkms.conf"
+}
+
+addtask do_setup after do_fetch before do_compile
+
+# The inherit of module.bbclass will automatically name module packages with
+# "kernel-module-" prefix as required by the oe-core build environment.
+
+RPROVIDES:${PN} += "kernel-module-canivore-usb"

--- a/recipes-kernel/canivore-usb-mod/files/Makefile
+++ b/recipes-kernel/canivore-usb-mod/files/Makefile
@@ -1,0 +1,16 @@
+obj-m := canivore-usb.o
+ccflags-y := -O2 -Wall -Wimplicit-fallthrough=3 -Werror
+canivore-usb-y := canivore-usb-drv.o canivore-usb-util.o
+
+SRC := $(shell pwd)
+
+all:
+	$(MAKE) -C $(KERNEL_SRC) M=$(SRC)
+
+modules_install:
+	$(MAKE) -C $(KERNEL_SRC) M=$(SRC) modules_install
+
+clean:
+	rm -f *.o *~ core .depend .*.cmd *.ko *.mod.c
+	rm -f Module.markers Module.symvers modules.order
+	rm -rf .tmp_versions Modules.symvers


### PR DESCRIPTION
This should let us run a carnivore off of an orin.

Shouldn't be merged yet, untested on an actual orin.